### PR TITLE
Hotfix: create_db_user: Make compatible with aws cli v2

### DIFF
--- a/.bumpsemver.cfg
+++ b/.bumpsemver.cfg
@@ -1,5 +1,5 @@
 [bumpsemver]
-current_version = 1.4.1
+current_version = 1.4.2
 commit = True
 tag = False
 tag_name = v{new_version}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ops-ci-aws
 
-**Current version: v1.4.1**
+**Current version: v1.4.2**
 
 This repository holds the shared Ansible roles, modules and tasks for projects to be deployed into AWS. It creates an Ansible collection.
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: ringier
 name: aws_cicd
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.4.1
+version: 1.4.2
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/create_db_user/tasks/main.yml
+++ b/roles/create_db_user/tasks/main.yml
@@ -71,21 +71,21 @@
 - name: '[{{ rds_db_name }}.{{ app_db_username }}] check if username already exists in SSM'
   command: aws --region {{ aws_region }} ssm get-parameter --name {{ ssmkey_rds_app_user_username_key }}
   register: result_name
-  failed_when: result_name.rc not in [0,255] or (result_name.rc == 255 and 'ParameterNotFound' not in result_name.stderr)
+  failed_when: result_name.rc != 0 and ('ParameterNotFound' not in result_name.stderr)
   changed_when: result_name.rc not in [0]
   no_log: true
 
 - name: '[{{ rds_db_name }}.{{ app_db_username }}] check if password already exists in SSM'
   command: aws --region {{ aws_region }} ssm get-parameter --name {{ ssmkey_rds_app_user_password_key }}
   register: result_pw
-  failed_when: result_pw.rc not in [0,255] or (result_pw.rc == 255 and 'ParameterNotFound' not in result_pw.stderr)
+  failed_when: result_pw.rc != 0 and ('ParameterNotFound' not in result_pw.stderr)
   changed_when: result_pw.rc not in [0]
   no_log: true
 
 - name: '[{{ rds_db_name }}.{{ app_db_username }}] set the flags'
   set_fact:
-    user_name_does_not_exist_in_ssm: "{{ result_name.rc == 255 and 'ParameterNotFound' in result_name.stderr }}"
-    user_pw_not_exist_in_ssm: "{{ result_pw.rc == 255 and 'ParameterNotFound' in result_pw.stderr }}"
+    user_name_does_not_exist_in_ssm: "{{ 'ParameterNotFound' in result_name.stderr }}"
+    user_pw_not_exist_in_ssm: "{{ 'ParameterNotFound' in result_pw.stderr }}"
 
 - name: '[{{ rds_db_name }}.{{ app_db_username }}] get user password'
   set_fact:


### PR DESCRIPTION
AWS CLI v2 changes the return code for when SSM Parameter is not found from 255 to 254. This change simplifies the logic so it only checks for text in stderr instead of also requiring specific return code.