### PR TITLE
[FEATURE] [RC-856] Allow opting out of Version tag

### DIFF
--- a/roles/run_cloudformation/defaults/main.yml
+++ b/roles/run_cloudformation/defaults/main.yml
@@ -3,3 +3,4 @@
 region: '{{ aws_region }}'
 template_parameters: {}
 infrastructure_bucket_override: ''
+skip_version_tag: false

--- a/roles/run_cloudformation/tasks/main.yml
+++ b/roles/run_cloudformation/tasks/main.yml
@@ -109,6 +109,6 @@
         Environment="{{ env }}"
         Name="{{ stack_name }}"
         Project="{{ project_id }}"
-        Version="v{{ project_version }}"
         Repository="{{ git_info.repo_name }}"
+        {{ '' if skip_version_tag else 'Version="v' + project_version + '"' }}
       --no-fail-on-empty-changeset


### PR DESCRIPTION
**Problem**
Some resources take a long time to update due to the Version tag. For example CloudFront stack ~3-5 minutes just to update the tag.

**Solution**
This change adds an option `skip_version_tag` to `run_cloudformation` which will skip the Version tag for this particular stack.

**Context**
Note: even if the Version-tag would be hardcoded to be static on all the individual resources which are slow to update (e.g. RDS, CloudFront) experiments showed that CloudFormation still updates the tags on the resources (i.e. from `"static"` to `"static"`) - which results in a 3-5 minute wait (for CloudFront) to update nothing. The only discovered way to solve this is to remove the Verison-tag from the stack itself.