### PR TITLE
[FEATURE] [RC-946] run_cloudformation: Use sam instead of cloudformation when Serverless transform is used

### DIFF
--- a/roles/run_cloudformation/tasks/main.yml
+++ b/roles/run_cloudformation/tasks/main.yml
@@ -79,7 +79,7 @@
 #
 - name: '[{{ stack_name }}] in case of SAM template: transform'
   command: >-
-    aws cloudformation package
+    sam package
        --template-file {{ workspace_path }}/cloudformation.yml
        --output-template-file {{ workspace_path }}/cloudformation-final.yml
        --s3-bucket {{ deployment_bucket }}

--- a/roles/run_cloudformation/tasks/main.yml
+++ b/roles/run_cloudformation/tasks/main.yml
@@ -97,7 +97,7 @@
 #
 - name: '[{{ stack_name }}] apply stack updates'
   command: >-
-    aws cloudformation deploy
+    {{ 'sam' if is_sam_required else 'aws cloudformation' }} deploy
       --template-file {{ workspace_path }}/cloudformation-final.yml
       --s3-bucket {{ deployment_bucket }}
       --s3-prefix {{ git_info.repo_name }}


### PR DESCRIPTION
**Problem**
Lambda functions in Serverless CloudFormation templates got issued a new version even though code did not change

**Solution**
Use the AWS `sam package` tool to package and deploy. Experiment showed this did not cause a new version to be created (CloudFormation stack was untouched) when deploying for the 2nd time - when reverting to old `aws cloudformation package` it did cause stack update on the 2nd time

Note: Based on experiments the stack needs to be deployed at least once using `sam package` for this to work. The 2nd time using `sam package` will cause no update, however the first will (even if no code changes).