### PR TITLE
[no-issue] Lock platform on docker build

### DIFF
--- a/roles/build_push_docker_image/tasks/build-image.yml
+++ b/roles/build_push_docker_image/tasks/build-image.yml
@@ -35,4 +35,4 @@
 
 - name: '[{{ ecr_repository_name }}] build the image'
   command: |
-    docker build --rm --quiet --tag {{ docker_image_with_tag }} {{ workspace_code_path }} --build-arg NPMRC_ENCODED="$NPMRC_ENCODED" {{ docker_build_args_str }}
+    docker build --platform linux/amd64 --rm --quiet --tag {{ docker_image_with_tag }} {{ workspace_code_path }} --build-arg NPMRC_ENCODED="$NPMRC_ENCODED" {{ docker_build_args_str }}


### PR DESCRIPTION
If a developer executing the build command on his local macOS running on apple-silicon, will most likely see the following log entry on aws:
```standard_init_linux.go:228: exec user process caused: exec format error```

The reason is that the docker image got build for arm64 instead of amd64.
This small adjustment would prevent that error from happening at all.