### PR TITLE
fix/docker-cross-compile

### DIFF
--- a/roles/build_push_docker_image/README.md
+++ b/roles/build_push_docker_image/README.md
@@ -24,9 +24,10 @@ This Ansible role:
 
 ## Outputs
 
-| Ansible variable                 | Type | Description                                                                                                                      |
-|:---------------------------------|:-----|:---------------------------------------------------------------------------------------------------------------------------------|
-| `docker_image_full_name_and_tag` | str  | ECR-specific tag for the published Docker image. e.g. `965749599769.dkr.ecr.eu-west-1.amazonaws.com/dev-scmi-crawler-cli:0.3.8.` |
+| Ansible variable                        | Type | Description                                                                                                                                                                                                                                                                                                                        |
+|:----------------------------------------|:-----|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `docker_image_full_name_and_tag`        | str  | ECR-specific tag for the published Docker image. e.g. `965749599769.dkr.ecr.eu-west-1.amazonaws.com/dev-scmi-crawler-cli:0.3.8.`                                                                                                                                                                                                   |
+| `docker_image_full_name_and_tag_<arch>` | str  | In case `adhoc_deploy` is truthy, these variables will be set to the SHA256 hash of the specific architecture. e.g. `docker_image_full_name_and_tag_arm64` = `180132115366.dkr.ecr.eu-central-1.amazonaws.com/dev-alloy-vectorizer-grafana-metrics-update@sha256:6d2b97ccacb063b2cf098a4c1932d5112d8742d6eb04aa5e26f7ce2c1b9e2078` |
 
 ## Examples
 

--- a/roles/build_push_docker_image/files/cf-ecr.yml
+++ b/roles/build_push_docker_image/files/cf-ecr.yml
@@ -18,13 +18,13 @@ Resources:
         # (II) we do not need to keep all tagged images forever, but to specify the amount of tagged images to keep,
         # we have to set `tagStatus` to `tagged`. This makes another property `tagPrefixList` mandatory. And the
         # `tagPrefixList` does not accept wildcard or empty value...the policies are applied sequentially one by one
-        # and no way to combine them with logical expression. So our workaround is to make the policies for the
+        # and no way to combine them with logical expression...even weird, tagStatus==untagged can only be used once.
+        # So our workaround is to make the policies for the
         # logic (order by priority, policy with smaller number will be applied earlier):
-        #   1. delete all untagged images older than 7 days
-        #   2. keep only 10 fresh but untagged images
-        #   3. for all images (irrelevant from the tagging status), we keep only 20 in total
+        #   1. keep only 10 fresh but untagged images
+        #   2. for all images (irrelevant from the tagging status), we keep only 20 in total
         # Therefore, at anytime, we may have 0~10 untagged images, and 0~20 tagged images. A gaussian random simulation
-        # of 10E4 times, 69% cases we ended up at 11 tagged images.
+        # of 10E4 times, 92% cases we ended up at 10:10 untagged:tagged images.
         # (III) at AWS, a junior secondary receptionist summer internship trainee is allowed to develop features and
         # ship to production without code review
         LifecyclePolicyText: |
@@ -32,19 +32,6 @@ Resources:
             "rules": [
               {
                 "rulePriority": 1,
-                "description": "Expire old untagged images after one week",
-                "selection": {
-                  "tagStatus": "untagged",
-                  "countType": "sinceImagePushed",
-                  "countNumber": 7,
-                  "countUnit": "days"
-                },
-                "action": {
-                  "type": "expire"
-                }
-              },
-              {
-                "rulePriority": 2,
                 "description": "Keep only 10 most recent untagged images",
                 "selection": {
                   "tagStatus": "untagged",

--- a/roles/build_push_docker_image/files/cf-ecr.yml
+++ b/roles/build_push_docker_image/files/cf-ecr.yml
@@ -10,52 +10,55 @@ Resources:
     Type: AWS::ECR::Repository
     Properties:
       RepositoryName: '{{ ecr_repository_name }}'
-      LifecyclePolicy:
-        # NOTE-zw:
-        # (I) the lovely AWS makes inconsistency between such a short distance. Here the `LifecyclePolicyText`
-        # is literally a text (of type String), while several lines down there, the `RepositoryPolicyText` is a
-        # JsonObject, therefore we could use the YAML representation...
-        # (II) we do not need to keep all tagged images forever, but to specify the amount of tagged images to keep,
-        # we have to set `tagStatus` to `tagged`. This makes another property `tagPrefixList` mandatory. And the
-        # `tagPrefixList` does not accept wildcard or empty value...the policies are applied sequentially one by one
-        # and no way to combine them with logical expression...even weird, tagStatus==untagged can only be used once.
-        # So our workaround is to make the policies for the
-        # logic (order by priority, policy with smaller number will be applied earlier):
-        #   1. keep only 10 fresh but untagged images
-        #   2. for all images (irrelevant from the tagging status), we keep only 20 in total
-        # Therefore, at anytime, we may have 0~10 untagged images, and 0~20 tagged images. A gaussian random simulation
-        # of 10E4 times, 92% cases we ended up at 10:10 untagged:tagged images.
-        # (III) at AWS, a junior secondary receptionist summer internship trainee is allowed to develop features and
-        # ship to production without code review
-        LifecyclePolicyText: |
-          {
-            "rules": [
-              {
-                "rulePriority": 1,
-                "description": "Keep only 10 most recent untagged images",
-                "selection": {
-                  "tagStatus": "untagged",
-                  "countType": "imageCountMoreThan",
-                  "countNumber": 10
-                },
-                "action": {
-                  "type": "expire"
-                }
-              },
-              {
-                "rulePriority": 50,
-                "description": "Keep only 20 images in total",
-                "selection": {
-                  "tagStatus": "any",
-                  "countType": "imageCountMoreThan",
-                  "countNumber": 20
-                },
-                "action": {
-                  "type": "expire"
-                }
-              }
-            ]
-          }
+# NOTE-zw[20230720]: even with the simple rules below, the cleanup logic is not appropriately executed. We have one
+# repository ended us with 18 untagged images and 3 tagged images (was 33 untagged + 17 tagged). It is too risky to
+# keep using this feature. We will disable it for now and create a separate lambda function to do the cleanup works.
+#      LifecyclePolicy:
+#        # NOTE-zw:
+#        # (I) the lovely AWS makes inconsistency between such a short distance. Here the `LifecyclePolicyText`
+#        # is literally a text (of type String), while several lines down there, the `RepositoryPolicyText` is a
+#        # JsonObject, therefore we could use the YAML representation...
+#        # (II) we do not need to keep all tagged images forever, but to specify the amount of tagged images to keep,
+#        # we have to set `tagStatus` to `tagged`. This makes another property `tagPrefixList` mandatory. And the
+#        # `tagPrefixList` does not accept wildcard or empty value...the policies are applied sequentially one by one
+#        # and no way to combine them with logical expression...even weird, tagStatus==untagged can only be used once.
+#        # So our workaround is to make the policies for the
+#        # logic (order by priority, policy with smaller number will be applied earlier):
+#        #   1. keep only 10 fresh but untagged images
+#        #   2. for all images (irrelevant from the tagging status), we keep only 20 in total
+#        # Therefore, at anytime, we may have 0~10 untagged images, and 0~20 tagged images. A gaussian random simulation
+#        # of 10E4 times, 92% cases we ended up at 10:10 untagged:tagged images.
+#        # (III) at AWS, a junior secondary receptionist summer internship trainee is allowed to develop features and
+#        # ship to production without code review
+#        LifecyclePolicyText: |
+#          {
+#            "rules": [
+#              {
+#                "rulePriority": 1,
+#                "description": "Keep only 10 most recent untagged images",
+#                "selection": {
+#                  "tagStatus": "untagged",
+#                  "countType": "imageCountMoreThan",
+#                  "countNumber": 10
+#                },
+#                "action": {
+#                  "type": "expire"
+#                }
+#              },
+#              {
+#                "rulePriority": 50,
+#                "description": "Keep only 20 images in total",
+#                "selection": {
+#                  "tagStatus": "any",
+#                  "countType": "imageCountMoreThan",
+#                  "countNumber": 20
+#                },
+#                "action": {
+#                  "type": "expire"
+#                }
+#              }
+#            ]
+#          }
 #{% if share_with_org_unit is defined and share_with_org_unit != '' %}
 #
       RepositoryPolicyText:

--- a/roles/build_push_docker_image/files/cf-ecr.yml
+++ b/roles/build_push_docker_image/files/cf-ecr.yml
@@ -11,36 +11,63 @@ Resources:
     Properties:
       RepositoryName: '{{ ecr_repository_name }}'
       LifecyclePolicy:
-        # NOTE-zw: the lovely AWS makes inconsistency between such a short distance. Here the `LifecyclePolicyText`
+        # NOTE-zw:
+        # (I) the lovely AWS makes inconsistency between such a short distance. Here the `LifecyclePolicyText`
         # is literally a text (of type String), while several lines down there, the `RepositoryPolicyText` is a
         # JsonObject, therefore we could use the YAML representation...
+        # (II) we do not need to keep all tagged images forever, but to specify the amount of tagged images to keep,
+        # we have to set `tagStatus` to `tagged`. This makes another property `tagPrefixList` mandatory. And the
+        # `tagPrefixList` does not accept wildcard or empty value...the policies are applied sequentially one by one
+        # and no way to combine them with logical expression. So our workaround is to make the policies for the
+        # logic (order by priority, policy with smaller number will be applied earlier):
+        #   1. delete all untagged images older than 7 days
+        #   2. keep only 10 fresh but untagged images
+        #   3. for all images (irrelevant from the tagging status), we keep only 20 in total
+        # Therefore, at anytime, we may have 0~10 untagged images, and 0~20 tagged images. A gaussian random simulation
+        # of 10E4 times, 69% cases we ended up at 11 tagged images.
+        # (III) at AWS, a junior secondary receptionist summer internship trainee is allowed to develop features and
+        # ship to production without code review
         LifecyclePolicyText: |
           {
-            "rules": [{
-              "rulePriority": 10,
-              "description": "Keep only 15 most recent tagged images",
-              "selection": {
-                "tagStatus": "tagged",
-                "countType": "imageCountMoreThan",
-                "countNumber": 15
+            "rules": [
+              {
+                "rulePriority": 1,
+                "description": "Expire old untagged images after one week",
+                "selection": {
+                  "tagStatus": "untagged",
+                  "countType": "sinceImagePushed",
+                  "countNumber": 7,
+                  "countUnit": "days"
+                },
+                "action": {
+                  "type": "expire"
+                }
               },
-              "action": {
-                "type": "expire"
-              }
-            },
-            {
-              "rulePriority": 100,
-              "description": "Expire old untagged images after one week",
-              "selection": {
-                "tagStatus": "untagged",
-                "countType": "sinceImagePushed",
-                "countNumber": 7,
-                "countUnit": "days"
+              {
+                "rulePriority": 2,
+                "description": "Keep only 10 most recent untagged images",
+                "selection": {
+                  "tagStatus": "untagged",
+                  "countType": "imageCountMoreThan",
+                  "countNumber": 10
+                },
+                "action": {
+                  "type": "expire"
+                }
               },
-              "action": {
-                "type": "expire"
+              {
+                "rulePriority": 50,
+                "description": "Keep only 20 images in total",
+                "selection": {
+                  "tagStatus": "any",
+                  "countType": "imageCountMoreThan",
+                  "countNumber": 20
+                },
+                "action": {
+                  "type": "expire"
+                }
               }
-            }]
+            ]
           }
 #{% if share_with_org_unit is defined and share_with_org_unit != '' %}
 #

--- a/roles/build_push_docker_image/files/cf-ecr.yml
+++ b/roles/build_push_docker_image/files/cf-ecr.yml
@@ -18,14 +18,11 @@ Resources:
           {
             "rules": [{
               "rulePriority": 10,
-              "description": "Keep only 15 most recent snapshot images",
+              "description": "Keep only 15 most recent tagged images",
               "selection": {
                 "tagStatus": "tagged",
                 "countType": "imageCountMoreThan",
-                "countNumber": 15,
-                "tagPrefixList": [
-                  "snapshot-"
-                ]
+                "countNumber": 15
               },
               "action": {
                 "type": "expire"

--- a/roles/build_push_docker_image/tasks/build-image.yml
+++ b/roles/build_push_docker_image/tasks/build-image.yml
@@ -16,7 +16,19 @@
 # SHA256 hash always points to an image for a specific platform.
 # As the solution to keep backwards compatibility, we introduce the following "output" logic:
 #
-#
+# 1. in case role parameter `adhoc_deploy` gets falsy, the Ansible variable `docker_image_full_name_and_tag` will be
+#    set to the image with version number as the tag. For example:
+#    `180132115366.dkr.ecr.eu-central-1.amazonaws.com/dev-alloy-vectorizer-grafana-metrics-update:1.1.2`
+# 2. if `adhoc_deploy` is truthy, and the platform determination logic decides to build a single-platform image, the
+#    Ansible variable `docker_image_full_name_and_tag_<arch>` (`<arch>` could normally be `arm64` or `amd64`) will be
+#    set to the image full name and tag, which could be used directly for
+#    `docker run --rm {{ docker_image_full_name_and_tag_arm64 }}`. For example:
+#    `180132115366.dkr.ecr.eu-central-1.amazonaws.com/dev-alloy-vectorizer-grafana-metrics-update@sha256:883f6f826487460252631dd383f15e90d815975f347f3445d0a258dbcc1e34a3`
+#    And `docker_image_full_name_and_tag` will be set exactly to the same value
+# 3. if `adhoc_deploy` is truthy, and the platform determination logic decides to build a multi-platform image, the
+#    Ansible variables `docker_image_full_name_and_tag_<arch>` (`<arch>` could normally be `arm64` or `amd64`) will be
+#    set to the image full name and tag for each platform, and `docker_image_full_name_and_tag` will be set to the same
+#    value as `docker_image_full_name_and_tag_arm64`
 ---
 
 - name: '[{{ ecr_repository_name }}] set image name and tag for the image to be built'

--- a/roles/build_push_docker_image/tasks/build-image.yml
+++ b/roles/build_push_docker_image/tasks/build-image.yml
@@ -86,7 +86,7 @@
     - name: '[{{ ecr_repository_name }}] install emulators'
       when: r_buildx_rcplus.rc != 0
       shell: |
-        docker run --privileged --rm docker.rcplus.io/tonistiigi/binfmt:buildkit-master --install arm64,amd64
+        docker run --privileged --rm docker.rcplus.io/tonistiigi/binfmt --install arm64,amd64
     - name: '[{{ ecr_repository_name }}] build the image'
       shell: |
         docker buildx build \

--- a/roles/build_push_docker_image/tasks/build-image.yml
+++ b/roles/build_push_docker_image/tasks/build-image.yml
@@ -86,7 +86,7 @@
     - name: '[{{ ecr_repository_name }}] install emulators'
       when: r_buildx_rcplus.rc != 0
       shell: |
-        docker run --privileged --rm tonistiigi/binfmt:buildkit-master --install arm64,amd64
+        docker run --privileged --rm docker.rcplus.io/tonistiigi/binfmt:buildkit-master --install arm64,amd64
     - name: '[{{ ecr_repository_name }}] build the image'
       shell: |
         docker buildx build \

--- a/roles/build_push_docker_image/tasks/build-image.yml
+++ b/roles/build_push_docker_image/tasks/build-image.yml
@@ -86,7 +86,7 @@
     - name: '[{{ ecr_repository_name }}] install emulators'
       when: r_buildx_rcplus.rc != 0
       shell: |
-        docker run --privileged --rm public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v7.0.0 --install arm64,amd64
+        docker run --privileged --rm tonistiigi/binfmt:buildkit-master --install arm64,amd64
     - name: '[{{ ecr_repository_name }}] build the image'
       shell: |
         docker buildx build \

--- a/roles/build_push_docker_image/tasks/build-image.yml
+++ b/roles/build_push_docker_image/tasks/build-image.yml
@@ -1,3 +1,22 @@
+# In case the prebuild-image is not supplied, the tasks in this file will be used to build the Docker image using the
+# specified Dockerfile.
+#
+# NOTE-zw: at the very beginning, we supported only single-platform image and tagged the image with
+# {{ project_version }} and `latest`. It implied a workflow, that for each change, we need to bump up the version so
+# that ECS or EKS would pull the updated image. To accelerate the development, role parameter `adhoc_deploy` was
+# introduced. It changes the "output" variable value of this role from '{{ ecr_registry_uri }}:{{ project_version }}'
+# to '{{ ecr_registry_uri }}@sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'. The SHA256 is
+# hash of the recently built image. So that whenever the image changes, the subsequent ECS task or EKS pod provisioning
+# task can always pick up the fresh image.
+# It has been working well for several years until we introduced the multi-platform build. In some edge cases, that the
+# determination logic decides to build a single-platform image but the build platform differs from the target platform,
+# the SHA256 would point to the manifest instead of the image. Then the error "CannotPullContainerError: pull image
+# manifest has been retried 5 time(s): unknown media type" came out. It is not difficult to fix this issue, but by the
+# nature of the design, we cannot easily use one output variable to hold the hashes for multi-platform image, as one
+# SHA256 hash always points to an image for a specific platform.
+# As the solution to keep backwards compatibility, we introduce the following "output" logic:
+#
+#
 ---
 
 - name: '[{{ ecr_repository_name }}] set image name and tag for the image to be built'
@@ -39,77 +58,73 @@
 - name: '[{{ ecr_repository_name }}] check Docker environment'
   command: docker version
 
-- name: 'do not use BuildKit if possible'
-  when: buildx_platform_param == local_platform
-  block:
-    - name: '[{{ ecr_repository_name }}] build the image'
-      command: |
-        docker build \
-          --rm \
-          --platform {{ local_platform }} \
-          --tag {{ docker_image_full_name_and_tag }} \
-          --tag {{ docker_image_full_name_with_latest_tag }} \
-          --build-arg NPMRC_ENCODED="$NPMRC_ENCODED" {{ docker_build_args_str }} \
-          {{ code_path }}
-      no_log: '{{ ansible_verbosity < 3 }}'
-    - name: '[{{ ecr_repository_name }}] push the image to ECR'
-      shell: 'docker push {{ docker_image_full_name_and_tag }} > /dev/null'
-    - name: '[{{ ecr_repository_name }}] tag the local image without scope'
-      command: 'docker tag {{ docker_image_full_name_and_tag}} {{ docker_image_with_tag }}'
-      no_log: '{{ ansible_verbosity < 3 }}'
-    - name: '[{{ ecr_repository_name }}] ad-hoc deployment: get the image repo digest'
-      when: adhoc_deploy
-      shell: docker inspect {{ docker_image_full_name_and_tag }} | jq -crM '.[0].RepoDigests[] | select(startswith("{{ ecr_registry_uri }}"))'
-      register: docker_inspect
-    - name: '[{{ ecr_repository_name }}] ad-hoc deployment: use the image repo digest as the docker image'
-      when: adhoc_deploy
-      set_fact:
-        docker_image_full_name_and_tag: '{{ docker_inspect.stdout }}'
+- name: '[{{ ecr_repository_name }}] check Docker BuildKit'
+  command: docker buildx version
 
-- name: 'use BuildKit if needed'
-  when: buildx_platform_param != local_platform
+- name: '[{{ ecr_repository_name }}] inspect our image builder'
+  command: docker buildx inspect rcplus
+  no_log: true
+  ignore_errors: true
+  register: r_buildx_rcplus
+
+- name: '[{{ ecr_repository_name }}] use the builder if available'
+  when: r_buildx_rcplus.rc == 0
+  command: docker buildx use rcplus
+
+- name: '[{{ ecr_repository_name }}] initialize the builder if needed'
+  when: r_buildx_rcplus.rc != 0
+  shell: |
+    docker buildx create --bootstrap --name rcplus --driver docker-container --platform linux/amd64,linux/arm64 --use --buildkitd-flags '--allow-insecure-entitlement security.insecure'
+
+- name: '[{{ ecr_repository_name }}] install emulators'
+  when: r_buildx_rcplus.rc != 0 and buildx_platform_param != local_platform
+  shell: |
+    docker run --privileged --rm docker.rcplus.io/tonistiigi/binfmt --install arm64,amd64
+
+- name: '[{{ ecr_repository_name }}] build the image'
+  shell: |
+    docker buildx build \
+      --allow security.insecure \
+      --push \
+      --platform {{ buildx_platform_param }} \
+      --builder rcplus {{ extra_buildx_build_args }} \
+      --tag {{ docker_image_full_name_and_tag }} \
+      --tag {{ docker_image_full_name_with_latest_tag }} \
+      --build-arg NPMRC_ENCODED="$NPMRC_ENCODED" {{ docker_build_args_str }} \
+      --provenance=false \
+      {{ code_path }}
+  no_log: '{{ ansible_verbosity < 3 }}'
+
+- name: '[{{ ecr_repository_name }}] modify the output in case of adhoc_deploy'
+  when: adhoc_deploy
+  no_log: '{{ ansible_verbosity < 3 }}'
   block:
-    - name: '[{{ ecr_repository_name }}] check Docker BuildKit'
-      command: docker buildx version
-    - name: '[{{ ecr_repository_name }}] inspect our image builder'
-      command: docker buildx inspect rcplus
-      no_log: true
-      ignore_errors: true
-      register: r_buildx_rcplus
-    - name: '[{{ ecr_repository_name }}] use the builder if available'
-      when: r_buildx_rcplus.rc == 0
-      command: docker buildx use rcplus
-    - name: '[{{ ecr_repository_name }}] initialize the builder if needed'
-      when: r_buildx_rcplus.rc != 0
-      shell: |
-        docker buildx create --bootstrap --name rcplus --driver docker-container --platform linux/amd64,linux/arm64 --use --buildkitd-flags '--allow-insecure-entitlement security.insecure'
-    - name: '[{{ ecr_repository_name }}] install emulators'
-      when: r_buildx_rcplus.rc != 0
-      shell: |
-        docker run --privileged --rm docker.rcplus.io/tonistiigi/binfmt --install arm64,amd64
-    - name: '[{{ ecr_repository_name }}] build the image'
-      shell: |
-        docker buildx build \
-          --allow security.insecure \
-          --push \
-          --platform {{ buildx_platform_param }} \
-          --builder rcplus {{ extra_buildx_build_args }} \
-          --tag {{ docker_image_full_name_and_tag }} \
-          --tag {{ docker_image_full_name_with_latest_tag }} \
-          --build-arg NPMRC_ENCODED="$NPMRC_ENCODED" {{ docker_build_args_str }} \
-          --provenance=false \
-          {% if adhoc_deploy %}--iidfile {{ code_path }}/docker-image-id {% endif %} \
-          {{ code_path }}
-      no_log: '{{ ansible_verbosity < 3 }}'
-    - when: adhoc_deploy
+    - name: '[{{ ecr_repository_name }}] inspect the manifest'
+      shell: docker manifest inspect --verbose {{ docker_image_full_name_with_latest_tag }}
+      register: r_manifest
+    - name: '[{{ ecr_repository_name }}] parse the inspection result'
+      set_fact:
+        manifest: '{{ r_manifest.stdout | from_json }}'
+    - name: '[{{ ecr_repository_name }}] extract hash for single-platform image'
+      when: manifest.Descriptor is defined
       block:
-        - name: '[{{ ecr_repository_name }}] ad-hoc deployment: fetch the image id'
-          shell: cat {{ code_path }}/docker-image-id
-          register: r_buildx_build
-        - name: '[{{ ecr_repository_name }}] ad-hoc deployment: use the image repo digest as the docker image'
+        - name: '[{{ ecr_repository_name }}](single-platform) extract the hash'
           set_fact:
-            docker_image_full_name_and_tag: '{{ ecr_registry_uri }}@{{ r_buildx_build.stdout }}'
-        - name: '[{{ ecr_repository_name }}] ad-hoc deployment: drop the image id file'
-          file:
-            path: '{{ code_path }}/docker-image-id'
-            state: absent
+            docker_image_full_name_with_latest_tag_{{ manifest.Descriptor.platform.architecture }}: '{{ ecr_registry_uri }}@{{ manifest.Descriptor.digest }}'
+        - name: '[{{ ecr_repository_name }}](single-platform) reset docker_image_full_name_with_latest_tag'
+          set_fact:
+            docker_image_full_name_with_latest_tag: '{{ vars["docker_image_full_name_with_latest_tag_" + manifest.Descriptor.platform.architecture] }}'
+    - name: '[{{ ecr_repository_name }}] extract hash for multi-platform image'
+      when: manifest.Descriptor is not defined
+      block:
+        - name: '[{{ ecr_repository_name }}](multi-platform) extract the hash of each image'
+          set_fact:
+            docker_image_full_name_with_latest_tag_{{ item.Descriptor.platform.architecture }}: '{{ ecr_registry_uri }}@{{ item.Descriptor.digest }}'
+          with_items: '{{ manifest }}'
+        - name: '[{{ ecr_repository_name }}](multi-platform) reset docker_image_full_name_with_latest_tag'
+          # assumption: when we build multi-platform image, one of the platform is arm64 (as RC+ default)
+          set_fact:
+            docker_image_full_name_with_latest_tag: '{{ docker_image_full_name_with_latest_tag_arm64 }}'
+    - debug:
+        msg: 'docker_image_full_name_with_latest_tag = "{{ docker_image_full_name_with_latest_tag }}"'
+      no_log: false

--- a/roles/build_push_docker_image/tasks/build-image.yml
+++ b/roles/build_push_docker_image/tasks/build-image.yml
@@ -122,21 +122,21 @@
       block:
         - name: '[{{ ecr_repository_name }}](single-platform) extract the hash'
           set_fact:
-            docker_image_full_name_with_latest_tag_{{ manifest.Descriptor.platform.architecture }}: '{{ ecr_registry_uri }}@{{ manifest.Descriptor.digest }}'
-        - name: '[{{ ecr_repository_name }}](single-platform) reset docker_image_full_name_with_latest_tag'
+            docker_image_full_name_and_tag_{{ manifest.Descriptor.platform.architecture }}: '{{ ecr_registry_uri }}@{{ manifest.Descriptor.digest }}'
+        - name: '[{{ ecr_repository_name }}](single-platform) reset docker_image_full_name_and_tag'
           set_fact:
-            docker_image_full_name_with_latest_tag: '{{ vars["docker_image_full_name_with_latest_tag_" + manifest.Descriptor.platform.architecture] }}'
+            docker_image_full_name_and_tag: '{{ vars["docker_image_full_name_and_tag_" + manifest.Descriptor.platform.architecture] }}'
     - name: '[{{ ecr_repository_name }}] extract hash for multi-platform image'
       when: manifest.Descriptor is not defined
       block:
         - name: '[{{ ecr_repository_name }}](multi-platform) extract the hash of each image'
           set_fact:
-            docker_image_full_name_with_latest_tag_{{ item.Descriptor.platform.architecture }}: '{{ ecr_registry_uri }}@{{ item.Descriptor.digest }}'
+            docker_image_full_name_and_tag_{{ item.Descriptor.platform.architecture }}: '{{ ecr_registry_uri }}@{{ item.Descriptor.digest }}'
           with_items: '{{ manifest }}'
-        - name: '[{{ ecr_repository_name }}](multi-platform) reset docker_image_full_name_with_latest_tag'
-          # assumption: when we build multi-platform image, one of the platform is arm64 (as RC+ default)
+        - name: '[{{ ecr_repository_name }}](multi-platform) reset docker_image_full_name_and_tag'
+          # assumption: when we build multi-platform image, one of the platform is arm64 (as the RC+ default)
           set_fact:
-            docker_image_full_name_with_latest_tag: '{{ docker_image_full_name_with_latest_tag_arm64 }}'
+            docker_image_full_name_and_tag: '{{ docker_image_full_name_and_tag_arm64 }}'
     - debug:
-        msg: 'docker_image_full_name_with_latest_tag = "{{ docker_image_full_name_with_latest_tag }}"'
+        msg: 'docker_image_full_name_and_tag = "{{ docker_image_full_name_and_tag }}"'
       no_log: false

--- a/roles/build_push_docker_image/tasks/platform-determination.yml
+++ b/roles/build_push_docker_image/tasks/platform-determination.yml
@@ -7,7 +7,7 @@
 #       (case-insensitive string), the corresponding boolean value will be respected. Otherwise,
 #    2. if the repo has '/deploydest.yml' with `multi_arch` as `true` (case-insensitive string), the image will be
 #       multi-arch. Otherwise,
-#    3 the image be NOT be multi-arch
+#    3 the image will NOT be multi-arch
 # B. in case we don't build multi-arch image:
 #    1. if `target_platform` does not exist in '/deploydest.yml', the image will be built for `amd64`. Otherwise,
 #    2. if the repo has '/deploydest.yml' with `target_platform` as `arm64` (in correspondence to architecture

--- a/roles/build_push_docker_image/tasks/setup-registry.yml
+++ b/roles/build_push_docker_image/tasks/setup-registry.yml
@@ -32,3 +32,8 @@
 - name: '[{{ ecr_repository_name }}] login to ECR'
   command: 'docker login --username AWS --password {{ r_ecr_password.stdout }} {{ ecr_registry_uri }}'
   no_log: '{{ ansible_verbosity < 3 }}'
+
+- name: '[{{ ecr_repository_name }}] login to rcplus Nexus'
+  # the authentication is in-place to prevent the registry from being accessed publicly.
+  command: 'docker login --username alloy-cicd --password ringier-alloy https://docker.rcplus.io/'
+  no_log: '{{ ansible_verbosity < 3 }}'

--- a/roles/init_workspace/README.md
+++ b/roles/init_workspace/README.md
@@ -10,7 +10,6 @@ This Ansible role:
 
 | Param               | Mandatory |  Type   | Default | Description                                                                                                           |
 |:--------------------|:---------:|:-------:|:--------|:----------------------------------------------------------------------------------------------------------------------|
-| `python3_workspace` |    No     | boolean | `false` | When truthy, a Python3 virtualenv will be initialized inside `workspace_path`                                         |
 | `use_eks`           |    No     | boolean | `false` | When truthy, adds a functioning context into local kubectl config for the EKS if the current environment is not `ops` |
 
 ## Outputs

--- a/roles/init_workspace/defaults/main.yml
+++ b/roles/init_workspace/defaults/main.yml
@@ -1,4 +1,3 @@
 ---
 
-python3_workspace: false
 use_eks: false

--- a/roles/init_workspace/tasks/create_workspace.yml
+++ b/roles/init_workspace/tasks/create_workspace.yml
@@ -9,14 +9,6 @@
 - set_fact:
     workspace_path: '{{ r_workspace.path }}'
 
-- name: 'initialize virtualenv and update pip'
-  pip:
-    extra_args: '-U'
-    name: 'pip'
-    virtualenv: '{{ workspace_path }}/venv'
-    virtualenv_python: 'python3'
-  when: python3_workspace | default(false) | bool
-
 - name: 'eks-specific setup'
   when: use_eks | default(false) | bool
   block:


### PR DESCRIPTION
* unified the Docker image build logic, because Docker uses BuildKit by default now, and `docker build` is just an alias of `docker buildx`
* fixed the logic of hash value retrieval when building arm64-only image from am amd64 machine
* enhanced the logic of hash value retrieval for multi-platform image
* switched from AWS-patched `binfmt` to the official image
* started using the Sonatype Nexus for RC+ as Docker proxy
* changed the ECR lifecycle rule to keep only recent 15 tagged images